### PR TITLE
Define Northwestern brand purple.

### DIFF
--- a/config/canopy.json
+++ b/config/canopy.json
@@ -1,16 +1,18 @@
 {
   "collection": "https://api.dc.library.northwestern.edu/api/v2/search?query=collection.id%3Aa2d334d8-8ea7-4dca-a65a-25509b76283c%20AND%20id%3D32fe4b01-c9a1-4436-827f-7d840ce125dbAND4d159d07-98e6-43c4-bba2-171a6aa906dcAND844a892d-a595-4727-a71d-41e69ad07f0fANDd4e3d25a-acc4-498c-8a26-c07f3c2ee46aAND581ee781-3f03-4fc0-8f44-013c241fab93ANDf09d0bf6-86dc-4b59-a8d3-42cc3a2b7d1fANDc8eec63b-7bb5-4d24-bc2d-251e2452bd11ANDd6bc7c03-49f0-4c2d-a6c8-32b25b45d29fAND531a8735-7dc5-4308-8921-a330cd0a8696ANDc8e48724-a514-4cb1-a338-e4a821b2fc1eAND7b242c48-d70e-4532-ad2f-d6906d2a01e0AND835d25ee-00e7-4150-834a-1fa78254be32ANDb2538ecd-f398-4802-a2c0-b49f419467a1&as=iiif&size=25",
- "search": {
+  "search": {
     "enabled": false
   },
-  "metadata": ["Contributor","Date","Genre"],
-    "label": {
-      "none": ["An American's Africa"]
-    },
-    "summary": {
-      "none": [
-        "Artifacts and other objects collected during Lydia Pederson's 1953 trip from Capetown, South Africa to Cairo, Egypt, and during Sonjia and Jim Olstad's 1967 stay in Nigeria: primarily beadwork, sculpture, carved calabashes, jewelry, and textiles. The collection includes a small amount of related material."
-      ]
-    }
-
+  "metadata": ["Contributor", "Date", "Genre"],
+  "label": {
+    "none": ["An American's Africa"]
+  },
+  "summary": {
+    "none": [
+      "Artifacts and other objects collected during Lydia Pederson's 1953 trip from Capetown, South Africa to Cairo, Egypt, and during Sonjia and Jim Olstad's 1967 stay in Nigeria: primarily beadwork, sculpture, carved calabashes, jewelry, and textiles. The collection includes a small amount of related material."
+    ]
+  },
+  "theme": {
+    "accentColor": "purple"
+  }
 }

--- a/src/styles/global.ts
+++ b/src/styles/global.ts
@@ -35,6 +35,39 @@ const defaults = {
       lineHeight: "1.47em",
     },
   },
+
+  /**
+   * define Radix Themes "purple" family as Northwestern brand colors
+   */
+  ".radix-themes": {
+    // baseline purples
+    "--purple-1": "rgb(228, 224, 238)", // Northwestern Purple 10
+    "--purple-2": "rgb(204, 196, 223)", // Northwestern Purple 20
+    "--purple-3": "rgb(182, 172, 209)", // Northwestern Purple 30
+    "--purple-4": "rgb(164, 149, 195)", // Northwestern Purple 40
+    "--purple-5": "rgb(147, 128, 182)", // Northwestern Purple 50
+    "--purple-6": "rgb(131, 110, 170)", // Northwestern Purple 60
+    "--purple-7": "rgb(118, 93, 160)", // Northwestern Purple 70
+    "--purple-8": "rgb(104, 76, 150)", // Northwestern Purple 80
+    "--purple-9": "rgb(78, 42, 132)", // Northwestern Purple, i.e., the brand
+    "--purple-10": "rgb(64, 31, 104)", // Northwestern Purple 120
+    "--purple-11": "rgb(48, 16, 78)", // Northwestern Purple 140
+    "--purple-12": "rgb(29, 2, 53)", // Northwestern Purple 160
+
+    // purples with alpha
+    "--purple-a1": "rgba(var(--purple-1), 0.382)",
+    "--purple-a2": "rgba(var(--purple-1), 0.618)",
+    "--purple-a3": "var(--purple-1)",
+    "--purple-a4": "var(--purple-2)",
+    "--purple-a5": "var(--purple-3)",
+    "--purple-a6": "var(--purple-4)",
+    "--purple-a7": "var(--purple-5)",
+    "--purple-a8": "var(--purple-6))",
+    "--purple-a9": "var(--purple-7)",
+    "--purple-a10": "var(--purple-8)",
+    "--purple-a11": "var(--purple-9)",
+    "--purple-a12": "var(--purple-10)",
+  },
 };
 
 const globalStyles = globalCss({


### PR DESCRIPTION
# What does this do?

This update would:

 1. Configure the `accentColor` as "purple" in the Radix Themes UI wrapping the Canopy IIIF project
 2. Define the "purple" color family according to Northwestern Brand purples as defined in https://www.northwestern.edu/brand/visual-identity/color-palettes/

![image](https://github.com/user-attachments/assets/c792f7f4-135b-4630-bfd6-ba6ed83469cc)
