### PR TITLE
Hotfix favicon link.

### DIFF
--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -9,6 +9,9 @@ import Document, {
 import { GoogleFontImport } from "@styles/theme/fonts";
 import React from "react";
 
+const basePath = process.env.NEXT_PUBLIC_BASE_PATH;
+const faviconPath = `${basePath}/images/favicon.png`;
+
 class CanopyDocument extends Document {
   static async getInitialProps(ctx: DocumentContext) {
     const initialProps = await Document.getInitialProps(ctx);
@@ -21,6 +24,7 @@ class CanopyDocument extends Document {
       <Html>
         <Head>
           <GoogleFontImport />
+          <link rel="icon" type="image/x-icon" href={faviconPath} />
         </Head>
         <body>
           <Main />

--- a/src/styles/global.ts
+++ b/src/styles/global.ts
@@ -3,14 +3,11 @@ import { globalCss } from "@stitches/react";
 export const rem = 20;
 export const headerHeight = 60.533333;
 
-<link rel="icon" type="image/x-icon" href="{{ '/images/favicon.png'}}">
-
 const defaults = {
   body: {
     margin: 0,
     padding: 0,
   },
-  
 
   html: {
     fontFamily: "$sans",
@@ -23,7 +20,7 @@ const defaults = {
   },
 
   h2: {
-    color: #757575,
+    color: "#757575",
   },
 
   "ul, ol": {


### PR DESCRIPTION
# What does this do?

This resolves a syntax issue in the global styles file cause by the `<link>` tag for the favicon. The favicon is now inserted into the document.tsx file and mapped to a basePath. Testing in github pages may be required after merge.